### PR TITLE
Use the environment variable SHOW_NON_RECURRENT_CALLERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Use the following command to trace the callers:
 ```
 $ LD_PRELOAD=libpreloaded_backtrace.so executable
 ```
-Two log files are genearted under the working directory in the format of `top_alloc_bytes_bt.{%pid}.{%tid}.log` and `top_num_calls_bt.{%pid}.{%tid}.log`. By default, top 10 callers are logged. The environment variable `NUM_TOPS` can control the number of callers. In addition, callers that just make one malloc/new are not logged as they are not the major source of page faults. To disable it, just set environment variable `SHOW_RECURRENT_CALLERS=1`.
+Two log files are genearted under the working directory in the format of `top_alloc_bytes_bt.{%pid}.{%tid}.log` and `top_num_calls_bt.{%pid}.{%tid}.log`. By default, top 10 callers are logged. The environment variable `NUM_TOPS` can control the number of callers. In addition, callers that just make one malloc/new are not logged as they are not the major source of page faults. To disable it, just set environment variable `SHOW_NON_RECURRENT_CALLERS=1`.
 
 To show the source code file name and the line numbers, run the following command:
 ```

--- a/src/backtrace_allocator.cpp
+++ b/src/backtrace_allocator.cpp
@@ -158,9 +158,9 @@ private:
 
     // We usually care about recurrent calls. If a call site just make one malloc,
     // it is not usually the target that we want to optimize away;
-    bool show_recurrent_callers = false;
-    if (getenv("SHOW_RECURRENT_CALLERS") && getenv("SHOW_RECURRENT_CALLERS")[0] == '1') {
-      show_recurrent_callers = true;
+    bool show_non_recurrent_callers = false;
+    if (getenv("SHOW_NON_RECURRENT_CALLERS") && getenv("SHOW_NON_RECURRENT_CALLERS")[0] == '1') {
+      show_non_recurrent_callers = true;
     }
 
     using bt_record_pair_t = std::pair<BackTrace, AllocRecord>;
@@ -181,7 +181,7 @@ private:
     std::priority_queue<bt_record_pair_t, std::vector<bt_record_pair_t>, decltype(cmp)> min_pq(cmp);
 
     for (const auto & [bt, record] : alloc_records_) {
-      if (show_recurrent_callers || record.num_calls_ > 1) {
+      if (show_non_recurrent_callers || record.num_calls_ > 1) {
         min_pq.push(bt_record_pair_t{bt, record});
         while (min_pq.size() > num_tops) {
           min_pq.pop();


### PR DESCRIPTION
As discussed in PR#11, Using SHOW_NON_RECURRENT_CALLERS can make our intention clearly. When this environment variable is set to 1, the backtraces are written to logs regardless of how many malloc/new are called by the call sites.